### PR TITLE
whatcd-api -> gazelle-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # WhatCD API
 
 Javascript WhatCD API based on promises.
+Quick and dirty fork of [whatcd-api](https://github.com/Christilut/whatcd-api) by [Christilut](https://github.com/Christilut) to be used on other trackers. All credit goes to him/her for this awesome script.
 
 # Installation
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,24 @@
-# WhatCD API
+# Gazelle API
 
-Javascript WhatCD API based on promises.
-Quick and dirty fork of [whatcd-api](https://github.com/Christilut/whatcd-api) by [Christilut](https://github.com/Christilut) to be used on other trackers. All credit goes to him/her for this awesome script.
+Javascript Gazelle API based on promises.
 
 # Installation
 
 Requires Node >= 6.0
 
-`npm install whatcd-api`
+`npm install gazelle-api`
 
 
 # Usage
 
-Check [WhatCD API](https://github.com/WhatCD/Gazelle/wiki/JSON-API-Documentation) for all available endpoints. For example, the browse action (which searches WhatCD) requires a `searchstr` parameter so you must add that in the object passed to `what.action()`.
+Check [WhatCD API](https://github.com/WhatCD/Gazelle/wiki/JSON-API-Documentation) for all available endpoints. For example, the browse action (which searches the tracker) requires a `searchstr` parameter so you must add that in the object passed to `gazelle.action()`.
 
 ```js
-const WhatCD = require('whatcd-api')
+const GazelleAPI = require('gazelle-api')
 
-const what = new WhatCD('whatcd_username', 'whatcd_password')
+const gazelle = new GazelleAPI('username', 'password', 'hostname')
 
-what.action('browse', {
+gazelle.action('browse', {
   searchstr: 'my favourite band'
 }).then(response => {
   console.log(response)
@@ -32,23 +31,23 @@ This library is rate limited to 5 requests per 10 seconds as specified by the Wh
 
 # API
 
-`what.action(action=string, parameters=object)`: Low level method to perform any action as described in the WhatCD API documentation.
+`gazelle.action(action=string, parameters=object)`: Low level method to perform any action as described in the WhatCD API documentation.
 
-`what.search(artist=string, album=string)`: Helper method that searches for an artist/album. It will start at 320kbps and search for a V0 release if nothing was found.
+`gazelle.search(artist=string, album=string)`: Helper method that searches for an artist/album. It will start at 320kbps and search for a V0 release if nothing was found.
 
-`what.download(id=integer, path=string)`: Helper method to download a .torrent file from the torrent ID that was supplied. Will save to specified path. Path must not include a filename.
+`gazelle.download(id=integer, path=string)`: Helper method to download a .torrent file from the torrent ID that was supplied. Will save to specified path. Path must not include a filename.
 
 # Testing
 
 `npm test` (will use fixtures)
 
 Some tests require a username and password:  
-`env WHATCD_USERNAME='' WHATCD_PASSWORD='' npm test -- -g 'login'`
+`env GAZELLE_USERNAME='' GAZELLE_PASSWORD='' npm run test`
 
-For a live test (caution):  
-`env WHATCD_USERNAME='' WHATCD_PASSWORD='' LIVE=true npm test -- -g 'search'`
+For a live test (not currently working):  
+`env GAZELLE_USERNAME='' GAZELLE_PASSWORD='' LIVE=true npm test -- -g 'search'`
 
-Careful not to get banned for multiple false login attempts.
+Careful not to get banned for multiple false login attempts. Some tests currently only work with PTH.
 
 # Contribute
 

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ Encoding = {
   V8: 'V8 (VBR)'
 }
 
-class WhatCD {
+class GazelleAPI {
 
   constructor(username, password, hostname) {
     this.domain = hostname
@@ -69,7 +69,7 @@ class WhatCD {
     if (!domain) throw new Error('domain parameter missing')
     if (params && typeof params !== 'object') throw new Error('invalid params parameter')
 
-    let uri = `${domain}/${endpoint}.php?action=${action}`
+    let uri = `${domain}${endpoint}.php?action=${action}`
 
     if (params) {
       for (let key of Object.keys(params)) {
@@ -144,7 +144,7 @@ class WhatCD {
 
         loginPromise.then(() => {
           const actionPromise = rp({
-              uri: WhatCD._buildUri(this.domain, endpoint, action, params),
+              uri: GazelleAPI._buildUri(this.domain, endpoint, action, params),
               method: 'GET',
               json: true,
               resolveWithFullResponse: true,
@@ -232,7 +232,7 @@ class WhatCD {
       'torrents',
       true
     ).then(response => {
-      const filename = WhatCD._extractFilename(response.headers)
+      const filename = GazelleAPI._extractFilename(response.headers)
 
       return fsp.writeFile(path.join(targetpath, filename), response.body, 'binary')
     })
@@ -240,4 +240,4 @@ class WhatCD {
   }
 }
 
-module.exports = WhatCD
+module.exports = GazelleAPI

--- a/index.js
+++ b/index.js
@@ -31,8 +31,8 @@ Encoding = {
 
 class WhatCD {
 
-  constructor(username, password) {
-    this.domain = 'https://ssl.what.cd'
+  constructor(username, password, hostname) {
+    this.domain = hostname
     this.username = username
     this.password = password
     this.loggedIn = false

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "whatcd-api",
-  "version": "1.0.0",
-  "description": "WhatCD API client based on promises",
+  "name": "gazelle-api",
+  "version": "1.1.0",
+  "description": "Gazelle tracker API client based on promises",
   "main": "index.js",
   "scripts": {
     "test": "./node_modules/.bin/mocha"


### PR DESCRIPTION
Made this a little more platform agnostic. Should work with most of the gazelle trackers that have popped up.
Shoot me an email and I'll relinquish the npm package if you want to rename and republish this (I was using it for a project so I don't want it to be unavailable in the meantime).